### PR TITLE
Add script to configure Cline settings and manage global state

### DIFF
--- a/docker/start-2-cline.sh
+++ b/docker/start-2-cline.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+source /custom-cont-init.d/common.sh || exit 1
+
+# Script to configure Cline settings
+# Usage: ./configure-cline.sh
+
+set -e
+
+GLOBAL_STATE="$HOME/.cline/data/globalState.json"
+chown abc:abc /usr/local/lib/node_modules
+chown abc:abc /usr/local/bin
+
+# Backup existing file
+if [ -f "$GLOBAL_STATE" ]; then
+    cp "$GLOBAL_STATE" "${GLOBAL_STATE}.backup.$(date +%Y%m%d_%H%M%S)"
+    echo "Backed up existing globalState.json"
+fi
+
+# Create the configuration with jq
+jq \
+    --arg planModeApiProvider "openai" \
+    --arg actModeApiProvider "openai" \
+    --arg openAiBaseUrl "http://localhost:7352/v1" \
+    --arg planModeOpenAiModelId "auto-fastest" \
+    --arg actModeOpenAiModelId "auto-fastest" \
+    '
+    .planModeApiProvider = $planModeApiProvider |
+    .actModeApiProvider = $actModeApiProvider |
+    .openAiBaseUrl = $openAiBaseUrl |
+    .planModeOpenAiModelId = $planModeOpenAiModelId |
+    .actModeOpenAiModelId = $actModeOpenAiModelId |
+    .actions = {
+        "readFiles": true,
+        "readFilesExternally": true,
+        "editFiles": true,
+        "editFilesExternally": true,
+        "executeSafeCommands": true,
+        "executeAllCommands": true,
+        "useBrowser": true,
+        "useMcp": true
+    }
+    ' "$GLOBAL_STATE" > /tmp/globalState.tmp && mv /tmp/globalState.tmp "$GLOBAL_STATE"
+
+echo "Cline settings updated successfully!"
+echo "Configured:"
+echo "  - planModeApiProvider: openai"
+echo "  - actModeApiProvider: openai"
+echo "  - openAiBaseUrl: http://localhost:7352/v1"
+echo "  - planModeOpenAiModelId: auto-fastest"
+echo "  - actModeOpenAiModelId: auto-fastest"
+echo "  - Actions: all enabled (read, edit, execute, browser, mcp)"


### PR DESCRIPTION
This pull request introduces a new shell script to automate and standardize the configuration of Cline settings in the Docker environment. The script ensures that the global state file is safely updated with the required API provider and model settings, and enables all available actions.

Configuration automation:

* Added a new script `start-2-cline.sh` that:
  - Backs up the existing `globalState.json` before making changes.
  - Uses `jq` to set API provider, model IDs, and enable all actions in `globalState.json`.
  - Changes ownership of relevant directories to user `abc`.
  - Provides clear output to indicate successful configuration and the values set.