### PR TITLE
Fix ownership of .cline/data directory after installing extensions

### DIFF
--- a/docker/start-4-codeserver.sh
+++ b/docker/start-4-codeserver.sh
@@ -34,6 +34,8 @@ chown abc:abc /usr/local/bin
     cp "${SCRIPT_DIR}/globalState.json" "$HOME/.cline/data/globalState.json"
     cp "${SCRIPT_DIR}/secrets.json" "$HOME/.cline/data/secrets.json"
     runuser -l abc -c "code --install-extension ${EXTENSION}"
+    chown -R abc:abc $HOME/.cline/data
+
   fi
 
   EXTENSION=joaompfp.hermes-ai-agent


### PR DESCRIPTION
This pull request introduces a small but important change to the `docker/start-4-codeserver.sh` script. After copying configuration files, it ensures the correct file ownership by recursively setting the owner and group of the `.cline/data` directory to `abc:abc`. This helps prevent permission issues when accessing these files as the `abc` user.

* Ensures `.cline/data` directory and its contents are owned by the `abc` user and group after copying configuration files.