### PR TITLE
A1+A2+C9: init reliability — Mnemon ordering, readiness probe, CI smoke test

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,15 +44,69 @@ jobs:
           
       - name: Test Docker image
         run: |
-          docker run --rm hermes-webtop:test > /tmp/test.log &
-          sleep 60
-          
-          # if grep -q "Data WebSocket Server listening on port 8082" /tmp/test.log; then
-          #   echo "Build successful"
-          # else
-          #   echo "Build failed!"
-          #   exit 1
-          # fi
+          CONTAINER_NAME="hermes-webtop-test"
+          TIMEOUT=120
+
+          # Start container with shm-size (required by webtop) and capture logs
+          docker run -d --name "$CONTAINER_NAME" \
+            --shm-size=1gb \
+            -p 3000:3000 \
+            hermes-webtop:test
+
+          # Wait for init scripts to complete (poll for known log markers)
+          echo "Waiting for startup scripts to complete..."
+          STARTED_AT=$(date +%s)
+          while true; do
+            NOW=$(date +%s)
+            ELAPSED=$((NOW - STARTED_AT))
+
+            if [ "$ELAPSED" -gt "$TIMEOUT" ]; then
+              echo "FAIL: Container did not finish init within ${TIMEOUT}s"
+              docker logs "$CONTAINER_NAME" --tail 100
+              docker kill "$CONTAINER_NAME" >/dev/null 2>&1 || true
+              exit 1
+            fi
+
+            LOGS=$(docker logs "$CONTAINER_NAME" 2>&1)
+
+            # Check for Hermes readiness (our A2 readiness probe)
+            if echo "$LOGS" | grep -q "Dashboard ready after"; then
+              echo "PASS: Hermes dashboard became healthy."
+              break
+            fi
+
+            # If we see Hermes services started but no dashboard probe, that's OK too
+            if echo "$LOGS" | grep -q "all hermes-agent services started and ready"; then
+              echo "PASS: Hermes services reported ready."
+              break
+            fi
+
+            sleep 5
+          done
+
+          # Quick sanity: container must still be running
+          if ! docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" --format "{{.Names}}" | grep -q "$CONTAINER_NAME"; then
+            echo "FAIL: Container stopped unexpectedly."
+            docker logs "$CONTAINER_NAME" --tail 50
+            docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+            exit 1
+          fi
+
+          # Verify at least one mapped port is responding
+          echo "Checking port 3000 (WebTop)..."
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 http://localhost:3000 2>/dev/null || echo "000")
+          if [ "$HTTP_CODE" = "000" ]; then
+            echo "WARN: Port 3000 did not respond (expected in headless CI). Check logs for context."
+            docker logs "$CONTAINER_NAME" --tail 30
+          else
+            echo "Port 3000 responded with HTTP $HTTP_CODE."
+          fi
+
+          # Cleanup
+          echo "Test complete. Stopping container..."
+          docker kill "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+          echo "PASS: Docker image smoke test passed."
         
   push-to-ghcr:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,10 +47,13 @@ jobs:
           CONTAINER_NAME="hermes-webtop-test"
           TIMEOUT=120
 
-          # Start container with shm-size (required by webtop) and capture logs
+          # Start container with shm-size (required by webtop) and all service ports mapped
           docker run -d --name "$CONTAINER_NAME" \
             --shm-size=1gb \
             -p 3000:3000 \
+            -p 8888:8888 \
+            -p 7352:7352 \
+            -p 20128:20128 \
             hermes-webtop:test
 
           # Wait for init scripts to complete (poll for known log markers)
@@ -92,15 +95,31 @@ jobs:
             exit 1
           fi
 
-          # Verify at least one mapped port is responding
-          echo "Checking port 3000 (WebTop)..."
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 http://localhost:3000 2>/dev/null || echo "000")
-          if [ "$HTTP_CODE" = "000" ]; then
-            echo "WARN: Port 3000 did not respond (expected in headless CI). Check logs for context."
+          # Verify all service ports are responding
+          FAILED_PORTS=""
+          echo ""
+          echo "=== Service Port Health Checks ==="
+          for pair in "3000:WebTop" "8888:CodeServer" "7352:ModelRelay" "20128:OmniRoute"; do
+            PORT="${pair%%:*}"
+            NAME="${pair##*:}"
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://localhost:${PORT}" 2>/dev/null || echo "000")
+            if [ "$HTTP_CODE" = "000" ]; then
+              echo "  $NAME (:$PORT) — ❌ no response"
+              FAILED_PORTS="$FAILED_PORTS $PORT"
+            else
+              echo "  $NAME (:$PORT) — ✅ HTTP $HTTP_CODE"
+            fi
+          done
+
+          if [ -n "$FAILED_PORTS" ]; then
+            echo ""
+            echo "WARN: Some ports did not respond:$FAILED_PORTS"
+            echo "      This may be expected in headless CI (WebTop display-dependent services)."
+            echo "      Check container logs for details: docker logs $CONTAINER_NAME --tail 50"
             docker logs "$CONTAINER_NAME" --tail 30
-          else
-            echo "Port 3000 responded with HTTP $HTTP_CODE."
           fi
+
+          echo ""
 
           # Cleanup
           echo "Test complete. Stopping container..."

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -95,31 +95,67 @@ jobs:
             exit 1
           fi
 
-          # Verify all service ports are responding
-          FAILED_PORTS=""
+          # Poll all service ports until all respond or timeout
+          PORT_POLL_TIMEOUT=60
+          POLL_STARTED_AT=$(date +%s)
+          declare -A RESPONDED
           echo ""
-          echo "=== Service Port Health Checks ==="
-          for pair in "3000:WebTop" "8888:CodeServer" "7352:ModelRelay" "20128:OmniRoute"; do
-            PORT="${pair%%:*}"
-            NAME="${pair##*:}"
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://localhost:${PORT}" 2>/dev/null) || HTTP_CODE="000"
-            # Trim trailing whitespace (curl -w can add newlines on some versions)
-            HTTP_CODE=$(echo "$HTTP_CODE" | tr -d '[:space:]')
-            if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" = "000" ]; then
-              echo "  $NAME (:$PORT) — ❌ no response"
-              FAILED_PORTS="$FAILED_PORTS $PORT"
-            else
-              echo "  $NAME (:$PORT) — ✅ HTTP $HTTP_CODE"
-            fi
-          done
+          echo "=== Polling Service Ports (${PORT_POLL_TIMEOUT}s timeout) ==="
 
-          if [ -n "$FAILED_PORTS" ]; then
-            echo ""
-            echo "WARN: Some ports did not respond:$FAILED_PORTS"
-            echo "      This may be expected in headless CI (WebTop display-dependent services)."
-            echo "      Check container logs for details: docker logs $CONTAINER_NAME --tail 50"
-            docker logs "$CONTAINER_NAME" --tail 30
-          fi
+          while true; do
+            NOW=$(date +%s)
+            ELAPSED=$((NOW - POLL_STARTED_AT))
+
+            if [ "$ELAPSED" -gt "$PORT_POLL_TIMEOUT" ]; then
+              echo ""
+              echo "→ FAIL: Port poll timeout after ${PORT_POLL_TIMEOUT}s — not all services responded"
+              for pair in "3000:WebTop" "8888:CodeServer" "7352:ModelRelay" "20128:OmniRoute"; do
+                PORT="${pair%%:*}"
+                NAME="${pair##*:}"
+                if [ "${RESPONDED[$PORT]}" != "true" ]; then
+                  echo "  • $NAME (:$PORT) — ❌ never responded"
+                fi
+              done
+              docker logs "$CONTAINER_NAME" --tail 50
+              docker kill "$CONTAINER_NAME" >/dev/null 2>&1 || true
+              docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+              exit 1
+            fi
+
+            for pair in "3000:WebTop" "8888:CodeServer" "7352:ModelRelay" "20128:OmniRoute"; do
+              PORT="${pair%%:*}"
+              NAME="${pair##*:}"
+
+              if [ "${RESPONDED[$PORT]}" = "true" ]; then
+                continue
+              fi
+
+              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://localhost:${PORT}" 2>/dev/null) || HTTP_CODE="000"
+              HTTP_CODE=$(echo "$HTTP_CODE" | tr -d '[:space:]')
+
+              if [ -n "$HTTP_CODE" ] && [ "$HTTP_CODE" != "000" ]; then
+                echo "  $NAME (:$PORT) — ✅ HTTP ${HTTP_CODE} (${ELAPSED}s)"
+                RESPONDED[$PORT]="true"
+              fi
+            done
+
+            # Check if all ports responded
+            ALL_RESPONDED=true
+            for port in 3000 8888 7352 20128; do
+              if [ "${RESPONDED[$port]}" != "true" ]; then
+                ALL_RESPONDED=false
+                break
+              fi
+            done
+
+            if [ "$ALL_RESPONDED" = "true" ]; then
+              echo ""
+              echo "→ PASS: All service ports responded within ${ELAPSED}s"
+              break
+            fi
+
+            sleep 5
+          done
 
           echo ""
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -102,8 +102,10 @@ jobs:
           for pair in "3000:WebTop" "8888:CodeServer" "7352:ModelRelay" "20128:OmniRoute"; do
             PORT="${pair%%:*}"
             NAME="${pair##*:}"
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://localhost:${PORT}" 2>/dev/null || echo "000")
-            if [ "$HTTP_CODE" = "000" ]; then
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "http://localhost:${PORT}" 2>/dev/null) || HTTP_CODE="000"
+            # Trim trailing whitespace (curl -w can add newlines on some versions)
+            HTTP_CODE=$(echo "$HTTP_CODE" | tr -d '[:space:]')
+            if [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" = "000" ]; then
               echo "  $NAME (:$PORT) — ❌ no response"
               FAILED_PORTS="$FAILED_PORTS $PORT"
             else

--- a/docker/start-hermes.sh
+++ b/docker/start-hermes.sh
@@ -90,5 +90,15 @@ EOF
 
 ) &
 
-# Let script to run in background properly
-sleep 15
+# Wait for Hermes dashboard to be ready (replaces brittle sleep 15)
+echo "[start-hermes] Waiting for Hermes dashboard to become healthy..."
+for i in $(seq 1 20); do
+  if curl -s -o /dev/null -w "%{http_code}" http://localhost:9119 2>/dev/null | grep -q "200\|302\|401"; then
+    echo "[start-hermes] Dashboard ready after $((i * 3)) seconds."
+    break
+  fi
+  if [ "$i" -eq 20 ]; then
+    echo "[start-hermes] WARNING: Dashboard did not respond within 60 seconds. Check ~/.hermes/logs/dashboard.log"
+  fi
+  sleep 3
+done

--- a/docker/start-hermes.sh
+++ b/docker/start-hermes.sh
@@ -50,11 +50,7 @@ runuser -l abc <<'EOF'
   ln -s /usr/local/lib/hermes-agent/venv/bin/pip3 /usr/local/lib/hermes-agent/venv/bin/pip || true
   /usr/local/lib/hermes-agent/venv/bin/pip install python-telegram-bot 2>/dev/null || true
 
-  # Start Hermes Gateway in background
-  echo "[start-hermes] Starting Hermes Gateway..."
-  nohup hermes gateway run --no-supervise > ~/.hermes/logs/gateway.log 2>&1 &
-
-  # update mnemon provider if version changes
+  # update mnemon provider if version changes (synced BEFORE gateway starts)
   echo "[start-hermes] Checking mnemon provider..."
   rm -rf /tmp/mnemon_repo
   if git clone https://github.com/gitricko/hermes-plugin-mnemon /tmp/mnemon_repo; then
@@ -71,6 +67,10 @@ runuser -l abc <<'EOF'
   else
     echo "[start-hermes] WARNING: Failed to clone gitricko/hermes-plugin-mnemon repository."
   fi
+
+  # Start Hermes Gateway in background (mnemon is ready before this fires)
+  echo "[start-hermes] Starting Hermes Gateway..."
+  nohup hermes gateway run --no-supervise > ~/.hermes/logs/gateway.log 2>&1 &
 
   # Start Hermes Dashboard in background
   ensure_ownership "/usr/local/lib/hermes-agent/hermes_cli"


### PR DESCRIPTION
## Summary

Three surgical reliability fixes for the container startup sequence, following the Karpathy "one fix per commit" discipline.

---

### Commit 1 — A1: Move Mnemon plugin sync before gateway start

**Problem**: The Mnemon plugin was cloned and diff-checked *after* `hermes gateway run` was launched in the background. On first boot, Telegram messages could arrive before the memory provider was ready — losing context.

**Fix**: Swap the order — sync Mnemon plugin first, then start the gateway. The diff check is fast (<1s on subsequent boots) so the delay is negligible.

`docker/start-hermes.sh` — 5 insertions, 5 deletions

---

### Commit 2 — A2: Replace brittle `sleep 15` with dashboard readiness probe

**Problem**: The script ended with `sleep 15` — a fixed timeout that either wastes time (fast boot) or is too short (slow Codespace). It was the most fragile pattern in the startup sequence.

**Fix**: 20-try readiness loop polling Hermes dashboard (port 9119) every 3 seconds. Logs `ready` on first success or a clear warning after 60 seconds with a pointer to the log file.

`docker/start-hermes.sh` — 12 insertions, 2 deletions

---

### Commit 3 — C9: Add real CI smoke test (replaces dead commented-out test)

**Problem**: The CI "Test Docker image" step ran the container for 60 seconds and did nothing with the output — every check was commented out. A broken image could land on GHCR silently.

**Fix**: 3-stage smoke test:
1. Start container with `--shm-size=1gb`, wait up to 120s for init scripts to complete (polling logs for `Dashboard ready` or `all hermes-agent services started and ready`)
2. Verify the container stays running after init completes
3. Attempt HTTP check on port 3000 (warns if headless CI can't reach it — init success is the real signal)
4. Clean up container on pass or fail; fails the workflow step if init doesn't complete

`.github/workflows/docker-publish.yml` — 63 insertions, 9 deletions

---

## How to test locally

```bash
# Verify the reordered init script
cat docker/start-hermes.sh | grep -A2 "mnemon.*before\|gateway.*after"

# Build and test the image locally
make docker-build
CONTAINER_NAME="hermes-webtop-test" && \
  docker run -d --name "$CONTAINER_NAME" --shm-size=1gb -p 3000:3000 hermes-webtop:latest && \
  docker logs -f "$CONTAINER_NAME"
```

## Checklist

- [x] A1: Mnemon syncs before gateway starts
- [x] A2: Readiness loop replaces sleep 15 (20 retries × 3s = 60s max)
- [x] C9: CI smoke test polls for real startup signals, fails on timeout or crash
- [ ] All existing functionality unchanged — purely additive/reordering changes
- [ ] Tested locally (container builds and starts)