### PR TITLE
fix: read Telegram credentials from .env instead of config.yaml

### DIFF
--- a/docker/self-check.sh
+++ b/docker/self-check.sh
@@ -341,13 +341,22 @@ EOF
 
 # ── Telegram delivery (auto-discovered from Hermes config) ──────────────────
 TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
-TELEGRAM_CHAT_ID=""
-
-# Read chat_id from Hermes config.yaml (check both allowed_chats and chat_id keys)
-if [ -f "$HERMES_CONFIG" ]; then
-  # Try telegram.chat_id first — guard with || true for set -e safety
+# Fall back to Hermes .env credential store if not set in env
+if [ -z "$TELEGRAM_BOT_TOKEN" ] && [ -f "$HOME/.hermes/.env" ]; then
+  TELEGRAM_BOT_TOKEN=$(grep '^TELEGRAM_BOT_TOKEN=' "$HOME/.hermes/.env" | head -1 | sed 's/^TELEGRAM_BOT_TOKEN=//' | tr -d '"' || true)
+fi
+TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-}"
+# Fall back to TELEGRAM_HOME_CHANNEL env var (Hermes convention)
+if [ -z "$TELEGRAM_CHAT_ID" ]; then
+  TELEGRAM_CHAT_ID="${TELEGRAM_HOME_CHANNEL:-}"
+fi
+# Fall back to Hermes .env credential store
+if [ -z "$TELEGRAM_CHAT_ID" ] && [ -f "$HOME/.hermes/.env" ]; then
+  TELEGRAM_CHAT_ID=$(grep '^TELEGRAM_HOME_CHANNEL=' "$HOME/.hermes/.env" | head -1 | sed 's/^TELEGRAM_HOME_CHANNEL=//' | tr -d '"' || true)
+fi
+# Fall back to config.yaml (backward compat)
+if [ -z "$TELEGRAM_CHAT_ID" ] && [ -f "$HERMES_CONFIG" ]; then
   TELEGRAM_CHAT_ID=$(grep -A10 '^telegram:' "$HERMES_CONFIG" 2>/dev/null | grep 'chat_id' | head -1 | sed 's/.*chat_id: *//' | tr -d '" ' | tr -d ' ') || true
-  # Fall back to allowed_chats if chat_id not found
   if [ -z "$TELEGRAM_CHAT_ID" ]; then
     TELEGRAM_CHAT_ID=$(grep -A10 '^telegram:' "$HERMES_CONFIG" 2>/dev/null | grep 'allowed_chats' | head -1 | sed 's/.*allowed_chats: *//' | tr -d '" ' | tr -d ' ') || true
   fi
@@ -406,7 +415,7 @@ if warns:
     -d "disable_web_page_preview=true" \
     --max-time 10 >/dev/null 2>&1 && echo "  [telegram] notification sent" || echo "  [telegram] failed to send"
 else
-  echo "  [telegram] not configured — stdout only (set TELEGRAM_BOT_TOKEN and configure telegram in ~/.hermes/config.yaml)"
+  echo "  [telegram] not configured — stdout only (set TELEGRAM_BOT_TOKEN and TELEGRAM_HOME_CHANNEL in ~/.hermes/.env)"
 fi
 
 exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary

The boot-time `self-check.sh` script was supposed to deliver a health report via Telegram on container restart, but it never fired because it looked for credentials in the wrong place.

## Root Cause

Two issues:

1. **Bot token**: The script read `TELEGRAM_BOT_TOKEN` only from shell environment variables, but Hermes stores it in `~/.hermes/.env` (its credential store), not as a shell env var.
2. **Chat ID**: The script parsed `telegram.chat_id` from `~/.hermes/config.yaml`, which doesn't exist by default (config.yaml is an OSS template — intentionally free of personal metadata).

## Fix

Both credentials now follow the same discovery pattern:

| Credential | Priority chain |
|---|---|
| Bot Token | `TELEGRAM_BOT_TOKEN` env var → `~/.hermes/.env` → `TELEGRAM_BOT_TOKEN` |
| Chat ID | `TELEGRAM_CHAT_ID` env var → `TELEGRAM_HOME_CHANNEL` env var → `~/.hermes/.env` → `TELEGRAM_HOME_CHANNEL` → `config.yaml` (backward compat) |

The config.yaml fallback is preserved so existing setups keep working.

**Why `.env`:** Hermes already stores `TELEGRAM_BOT_TOKEN` and `TELEGRAM_HOME_CHANNEL` in `~/.hermes/.env`. It's the single canonical source for Telegram credentials — no need to duplicate in config.yaml.

## How to test locally

Run the self-check script to verify Telegram delivery fires:

```bash
# Verify credentials resolve (shows length only — no value leak)
if [ -n "$TELEGRAM_BOT_TOKEN" ]; then echo "Token: resolved (${#TELEGRAM_BOT_TOKEN} chars)"; else echo "Token: MISSING"; fi
if [ -n "$TELEGRAM_HOME_CHANNEL" ]; then echo "Chat ID: resolved"; else echo "Chat ID: MISSING"; fi

# Run the check script
/usr/local/bin/self-check
```

Expected output includes:
```
PASSED — all checks ok
[telegram] notification sent
```

## Files changed

| File | Change |
|---|---|
| `docker/self-check.sh` | +16/-7 — Token reads from .env; chat ID reads from .env (env vars → .env → config.yaml) |

## Checklist

- [x] Script patched — both credentials resolve from .env
- [x] Live binary at `/usr/local/bin/self-check` also patched
- [x] Config.yaml fallback preserved (backward compat)
- [x] Verified dry-run: both credentials resolve correctly
- [x] Wiki docs updated (telegram-delivery-design.md, reboot-self-diagnostics.md)
- [x] No changes to config.yaml, start-hermes.sh, or any OSS template
- [x] For this PR: scanned full body for credential patterns — all clean