### PR TITLE
feat: purge stale ACP sessions on boot to fix VSCode extension

### DIFF
--- a/docker/self-check.sh
+++ b/docker/self-check.sh
@@ -90,6 +90,48 @@ echo "  ${BOLD}HERMES-WEBTOP HEALTH REPORT${NC}"
 echo "  $(date -u)"
 echo " ════════════════════════════════════════════════════════════"
 
+# ── 0. Cleanup ───────────────────────────────────────────────────────────────
+# Purge stale ACP sessions from state.db. These are VSCode/IDE extension
+# sessions that get persisted across container reboots but become unrecoverable
+# because the saved provider config (billing_provider, model) no longer matches
+# the current runtime config. Deleting them on every boot lets the VSCode
+# extension fall through gracefully to creating a fresh session.
+section "Cleanup"
+STATE_DB="${HOME:-/config}/.hermes/state.db"
+if [ -f "$STATE_DB" ]; then
+  python3 -c "
+import sqlite3, os
+db_path = os.path.expanduser('$STATE_DB')
+try:
+    db = sqlite3.connect(db_path)
+    cursor = db.execute(\"SELECT COUNT(*) FROM sessions WHERE source='acp'\")
+    count = cursor.fetchone()[0]
+    if count > 0:
+        db.execute(\"DELETE FROM sessions WHERE source='acp'\")
+        db.commit()
+        print(count)
+    else:
+        print(0)
+    db.close()
+except Exception:
+    print(-1)
+" 2>/dev/null | while read n; do
+    if [ "$n" -gt 0 ]; then
+      _ok "ACP sessions" "purged ${n} stale session(s) from state.db"
+      json_add "cleanup:acp-sessions" "ok" "purged ${n} stale sessions" "{\"purged\":${n}}"
+    elif [ "$n" = "0" ]; then
+      _ok "ACP sessions" "none to clean"
+      json_add "cleanup:acp-sessions" "ok" "no stale sessions" "{}"
+    else
+      _warn "ACP sessions" "cleanup query failed"
+      json_add "cleanup:acp-sessions" "warn" "cleanup failed" "{}"
+    fi
+  done
+else
+  _ok "ACP sessions" "no state.db yet"
+  json_add "cleanup:acp-sessions" "ok" "state.db not found" "{}"
+fi
+
 # ── 1. Services ──────────────────────────────────────────────────────────────
 section "Services"
 

--- a/docker/self-check.sh
+++ b/docker/self-check.sh
@@ -91,37 +91,63 @@ echo "  $(date -u)"
 echo " ════════════════════════════════════════════════════════════"
 
 # ── 0. Cleanup ───────────────────────────────────────────────────────────────
-# Purge stale ACP sessions from state.db. These are VSCode/IDE extension
-# sessions that get persisted across container reboots but become unrecoverable
-# because the saved provider config (billing_provider, model) no longer matches
-# the current runtime config. Deleting them on every boot lets the VSCode
-# extension fall through gracefully to creating a fresh session.
+# Purge stale ACP sessions from state.db. ACP sessions are VSCode/IDE extension
+# sessions that persist in state.db across container reboots. Some may still be
+# recoverable (if their saved billing_provider still exists in the current
+# config), others are unrecoverable (provider was removed/renamed).
+#
+# This checks each session individually: only deletes sessions whose
+# billing_provider no longer matches a configured provider, so recoverable
+# sessions from the same container lifetime are preserved.
 section "Cleanup"
 STATE_DB="${HOME:-/config}/.hermes/state.db"
 if [ -f "$STATE_DB" ]; then
   python3 -c "
-import sqlite3, os
+import sqlite3, os, yaml
+
 db_path = os.path.expanduser('$STATE_DB')
+cfg_path = os.path.expanduser('~/.hermes/config.yaml')
+
 try:
+    # 1. Build set of configured providers
+    configured = set()
+    with open(cfg_path) as f:
+        cfg = yaml.safe_load(f) or {}
+    configured.update((cfg.get('providers') or {}).keys())
+    configured.update((cfg.get('custom_providers') or {}).keys())
+    mc = cfg.get('model', {})
+    if isinstance(mc, dict) and mc.get('provider'):
+        configured.add(mc['provider'])
+
+    # 2. Check each ACP session
     db = sqlite3.connect(db_path)
-    cursor = db.execute(\"SELECT COUNT(*) FROM sessions WHERE source='acp'\")
-    count = cursor.fetchone()[0]
-    if count > 0:
-        db.execute(\"DELETE FROM sessions WHERE source='acp'\")
-        db.commit()
-        print(count)
-    else:
-        print(0)
+    rows = db.execute('''
+        SELECT id, billing_provider FROM sessions
+        WHERE source='acp'
+    ''').fetchall()
+    
+    purged = 0
+    kept = 0
+    for sid, bp in rows:
+        if bp is None or bp in configured:
+            kept += 1
+        else:
+            purged += 1
+            db.execute('DELETE FROM sessions WHERE id=?', (sid,))
+    db.commit()
     db.close()
+    print(f'{purged} {kept}')
 except Exception:
-    print(-1)
-" 2>/dev/null | while read n; do
-    if [ "$n" -gt 0 ]; then
-      _ok "ACP sessions" "purged ${n} stale session(s) from state.db"
-      json_add "cleanup:acp-sessions" "ok" "purged ${n} stale sessions" "{\"purged\":${n}}"
-    elif [ "$n" = "0" ]; then
-      _ok "ACP sessions" "none to clean"
-      json_add "cleanup:acp-sessions" "ok" "no stale sessions" "{}"
+    print('-1 -1')
+" 2>/dev/null | while read purged kept; do
+    [ -z "$purged" ] && purged=0
+    [ -z "$kept" ] && kept=0
+    if [ "$purged" -gt 0 ] 2>/dev/null; then
+      _ok "ACP sessions" "purged ${purged} stale session(s), kept ${kept}"
+      json_add "cleanup:acp-sessions" "ok" "purged ${purged} stale, kept ${kept}" "{\"purged\":${purged},\"kept\":${kept}}"
+    elif [ "$purged" = "0" ] 2>/dev/null && [ "$kept" -ge 0 ] 2>/dev/null; then
+      _ok "ACP sessions" "none to clean (${kept} kept)"
+      json_add "cleanup:acp-sessions" "ok" "no stale sessions" "{\"kept\":${kept}}"
     else
       _warn "ACP sessions" "cleanup query failed"
       json_add "cleanup:acp-sessions" "warn" "cleanup failed" "{}"


### PR DESCRIPTION
## Problem

After every container reboot, the `custom` provider used by old ACP sessions no longer exists in the Hermes config. The ACP server's `_restore()` fails silently, and the VSCode extension routes messages into a broken ghost session.

## Root Cause

ACP sessions save `billing_provider` at creation time. After a container rebuild, if that provider was removed from config.yaml (or never existed as a `providers.` entry), the server cannot recreate the AI agent — `resolve_runtime_provider` resolves fine but returns `api_key=None`, causing `AIAgent.__init__` to raise `RuntimeError: No LLM provider configured`. The `session/load` handler returns `null`, but by that point the extension's `ensureSession` logic treats any truthy response as a successful resume.

## Fix

Add a **Cleanup** section at the top of `self-check.sh` (runs every boot) that:

1. Loads the current Hermes config and builds a set of configured providers (from `providers:`, `custom_providers:`, and the active `model.provider`)
2. Iterates each ACP session in state.db
3. **Only deletes sessions** whose `billing_provider` is neither `None` (uses current default) nor present in the configured set
4. **Preserves recoverable sessions** that match a currently configured provider

This is smarter than blanket-deleting all ACP sessions — if you use a stable provider like `omniroute`, those sessions survive reboots fine.

## Testing

### Real VSCode test (recommended)

1. Open VSCode and use the Hermes extension for a while — ask a few questions, let it create 2–3 sessions naturally
2. Verify the sessions are visible in the extension's session list
3. Reboot the container (`docker restart <container>`)
4. Re-open VSCode — the extension should auto-connect with a fresh session
5. Check the session list: sessions using a still-configured provider (e.g. `omniroute`) should remain; sessions using a removed provider (e.g. `custom`) should be gone
6. Type a message — verify it gets a response (the real pass/fail signal)

### Automated smoke test (quick verify)

Run just the cleanup section against the current state.db:

```bash
cd /config/Documents/_code/hermes-webtop
SKIP_CHECKS="services,models,mnemon,hermes,disk,memory,cron" \
  bash docker/self-check.sh 2>&1 | grep -A2 'Cleanup'
```

Expected when no stale sessions exist: `✅ ACP sessions       none to clean (N kept)`

## PR Workflow
- [x] Loaded `karpathy-coding-guidelines` skill before writing code
- [x] `git pull origin main` before branching
- [x] Branch from `main`
- [x] Surgical single-commit
- [x] No hardcoded credentials
- [x] Tested locally