### PR TITLE
WONT-FIX: fix: update stale ACP session provider instead of deleting

### DIFF
--- a/docker/self-check.sh
+++ b/docker/self-check.sh
@@ -90,20 +90,25 @@ echo "  ${BOLD}HERMES-WEBTOP HEALTH REPORT${NC}"
 echo "  $(date -u)"
 echo " ════════════════════════════════════════════════════════════"
 
-# ── 0. Cleanup ───────────────────────────────────────────────────────────────
-# Purge stale ACP sessions from state.db. ACP sessions are VSCode/IDE extension
-# sessions that persist in state.db across container reboots. Some may still be
-# recoverable (if their saved billing_provider still exists in the current
-# config), others are unrecoverable (provider was removed/renamed).
+# ── 0. Fix ACP sessions ───────────────────────────────────────────────────────
+# Fix stale ACP sessions in state.db. ACP sessions are VSCode/IDE extension
+# sessions that persist in state.db across container reboots. Their saved
+# billing_provider may no longer exist in the current config.
 #
-# This checks each session individually: only deletes sessions whose
-# billing_provider no longer matches a configured provider, so recoverable
-# sessions from the same container lifetime are preserved.
+# IMPORTANT: We do NOT delete stale sessions. The ACP server's normalize_result
+# converts None from load_session into {} (empty dict). The extension interprets
+# {} as a successful load -- creating a "ghost session" that never responds.
+# Deleting the session makes this WORSE because the extension's locally-cached
+# session ID becomes a ghost with no escape hatch.
+#
+# Instead we UPDATE the provider to the current configured one and clear old
+# messages. This makes session/load succeed and the extension resumes with
+# a clean working conversation.
 section "Cleanup"
 STATE_DB="${HOME:-/config}/.hermes/state.db"
 if [ -f "$STATE_DB" ]; then
   python3 -c "
-import sqlite3, os, yaml
+import sqlite3, os, yaml, json
 
 db_path = os.path.expanduser('$STATE_DB')
 cfg_path = os.path.expanduser('~/.hermes/config.yaml')
@@ -119,34 +124,53 @@ try:
     if isinstance(mc, dict) and mc.get('provider'):
         configured.add(mc['provider'])
 
-    # 2. Check each ACP session
+    # 2. Read current model provider as the replacement
+    current_provider = mc.get('provider') if isinstance(mc, dict) else None
+    if not current_provider:
+        current_provider = 'omniroute'
+    current_base_url = ''
+    providers_cfg = cfg.get('providers', {}) or {}
+    curr = providers_cfg.get(current_provider, {}) or {}
+    current_base_url = curr.get('base_url', '')
+
+    # 3. Check each ACP session
     db = sqlite3.connect(db_path)
     rows = db.execute('''
         SELECT id, billing_provider FROM sessions
         WHERE source='acp'
     ''').fetchall()
-    
-    purged = 0
+
+    fixed = 0
     kept = 0
     for sid, bp in rows:
         if bp is None or bp in configured:
             kept += 1
         else:
-            purged += 1
-            db.execute('DELETE FROM sessions WHERE id=?', (sid,))
+            # Fix: update provider to current, clear messages
+            db.execute('''
+                UPDATE sessions SET billing_provider=?,
+                    billing_base_url=?, billing_mode='chat_completions',
+                    model_config=?
+                WHERE id=?
+            ''', (current_provider, current_base_url,
+                  json.dumps({'provider': current_provider,
+                              'base_url': current_base_url}),
+                  sid))
+            db.execute('DELETE FROM messages WHERE session_id=?', (sid,))
+            fixed += 1
     db.commit()
     db.close()
-    print(f'{purged} {kept}')
+    print(f'{fixed} {kept}')
 except Exception:
     print('-1 -1')
-" 2>/dev/null | while read purged kept; do
-    [ -z "$purged" ] && purged=0
+" 2>/dev/null | while read fixed kept; do
+    [ -z "$fixed" ] && fixed=0
     [ -z "$kept" ] && kept=0
-    if [ "$purged" -gt 0 ] 2>/dev/null; then
-      _ok "ACP sessions" "purged ${purged} stale session(s), kept ${kept}"
-      json_add "cleanup:acp-sessions" "ok" "purged ${purged} stale, kept ${kept}" "{\"purged\":${purged},\"kept\":${kept}}"
-    elif [ "$purged" = "0" ] 2>/dev/null && [ "$kept" -ge 0 ] 2>/dev/null; then
-      _ok "ACP sessions" "none to clean (${kept} kept)"
+    if [ "$fixed" -gt 0 ] 2>/dev/null; then
+      _ok "ACP sessions" "fixed ${fixed} stale session(s), kept ${kept}"
+      json_add "cleanup:acp-sessions" "ok" "fixed ${fixed} stale, kept ${kept}" "{\"fixed\":${fixed},\"kept\":${kept}}"
+    elif [ "$fixed" = "0" ] 2>/dev/null && [ "$kept" -ge 0 ] 2>/dev/null; then
+      _ok "ACP sessions" "none to fix (${kept} kept)"
       json_add "cleanup:acp-sessions" "ok" "no stale sessions" "{\"kept\":${kept}}"
     else
       _warn "ACP sessions" "cleanup query failed"


### PR DESCRIPTION
## Problem

After every container reboot, the `custom` provider used by old ACP sessions no longer exists in the Hermes config. The extension cached these session IDs locally in VSCode workspaceState. On reconnect it tries `session/load`, but ...

**The real root cause (found post-merge of PR #25):**

The ACP server's `normalize_result()` adapter converts any `None` return from `load_session` into `{}` (empty dict):

```python
def normalize_result(payload: Any) -> dict[str, Any]:
    if payload is None:
        return {}  # ← None becomes empty dict, which is TRUTHY in JS
```

The extension checks `if (null != await call("session/load", ...))`. Since an empty dict `{}` is truthy in JavaScript, the extension thinks the session loaded and logs "resumed" — but the agent never actually existed. Every subsequent `session/prompt` then fails with "session not found", creating a phantom session that never responds.

**Deleting the session (previous fix PR #25) made this worse** — the DB row is gone, but `normalize_result` still returns `{}` (truthy), so the extension stays stuck on the phantom session with no escape hatch.

## Fix

Instead of **deleting** stale sessions, **UPDATE** them:

1. Set `billing_provider` to the current configured provider (e.g. `omniroute`)
2. Set `billing_base_url` to the current OmniRoute endpoint
3. Set `model_config` to a valid config with the current provider
4. **Clear old messages** so history replay is a clean slate

The session ID is preserved, so the extension's locally-cached ID still resolves. The server creates a working agent with the current provider. The extension resumes with a clean conversation.

## How it works

On boot, `self-check.sh` queries `~/.hermes/state.db` for ACP sessions (`source='acp'`) whose `billing_provider` is no longer in the current config. For each stale session it runs:

```python
UPDATE sessions SET billing_provider='omniroute', billing_base_url='http://localhost:20128/v1',
    billing_mode='chat_completions', model_config='{"provider":"omniroute","base_url":"http://localhost:20128/v1"}'
WHERE id='<stale-session-id>'
DELETE FROM messages WHERE session_id='<stale-session-id>'
```

Sessions with `billing_provider` still configured (e.g. `omniroute`, `modelrelay`) or `None` (uses current default) are left untouched.

## Testing

### Automated smoke test
```bash
cd /config/Documents/_code/hermes-webtop

# 1. Insert a stale ACP session
python3 -c "
import sqlite3, json
db = sqlite3.connect('/config/.hermes/state.db')
db.execute(\"\"\"INSERT OR REPLACE INTO sessions
  (id, source, billing_provider, billing_base_url, billing_mode,
   model, started_at, title, model_config)
  VALUES ('test-stale', 'acp', 'custom',
   'http://localhost:20128/v1', 'chat_completions',
   'auto-fastest', 1, 'Test',
   '{\"provider\":\"custom\",\"base_url\":\"http://localhost:20128/v1\"}')\"\"\")
db.commit()
db.close()
"

# 2. Run the cleanup
SKIP_CHECKS="services,models,mnemon,hermes,disk,memory,cron" \
  bash docker/self-check.sh 2>&1 | grep -A2 'Cleanup'
# Expected: "fixed 1 stale session(s), kept 0"

# 3. Verify session was KEPT with updated provider
python3 -c "
import sqlite3
db = sqlite3.connect('/config/.hermes/state.db')
r = db.execute('SELECT billing_provider, billing_base_url FROM sessions WHERE id=?', ('test-stale',)).fetchone()
print(f'provider={r[0]} base_url={r[1]}')
msgs = db.execute('SELECT COUNT(*) FROM messages WHERE session_id=?', ('test-stale',)).fetchone()
print(f'messages={msgs[0]}')
db.close()
"
# Expected: "provider=omniroute base_url=http://localhost:20128/v1  messages=0"
```

### Real VSCode test
1. Use the Hermes extension in VSCode for a while — create 2-3 ACP sessions by asking questions
2. Open a terminal in the container and check ACP sessions exist:
   ```
   sqlite3 /config/.hermes/state.db "SELECT id, billing_provider, title FROM sessions WHERE source='acp'"
   ```
3. **Reboot the container** via `docker restart <container>`
4. Wait for code-server to come back, open VSCode
5. Open the extension — it should auto-connect
6. **The session list should show old sessions** (IDs preserved)
7. **Type a message** in any session — it should respond (server creates agent with current provider, conversation starts clean)
8. Verify the fix ran in boot logs:
   ```
   journalctl -u docker 2>/dev/null | grep -i "acp session"
   ```
   Or check the self-check output from the container boot log
