### PR TITLE
feat(docker): bake herdr + tmux into webtop image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,9 @@ ARG MODELRELAY_VERSION=1.18.0
 ARG OLLAMA_VERSION=0.32.6
 ARG NODE_VERSION=26.7.0
 ARG CODE_SERVER_VERSION=4.131.0
-ARG MNEMON_VERSION=0.2.3
 ARG PI_VERSION=0.84.2
+ARG MNEMON_VERSION=0.2.3
+ARG HERDR_VERSION=0.7.4
 ARG TARGETARCH
 
 # Use the official Ollama image to get the binary
@@ -29,7 +30,7 @@ RUN GH_ARCH="${GH_ARCH:-${TARGETARCH:-amd64}}"; \
     && echo "deb [arch=${GH_ARCH} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list 
 
 # Install help utilities and clean up apt cache to reduce image size
-RUN apt-get update && apt-get install -y htop zsh ripgrep gh remmina iputils-ping net-tools socat && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y htop zsh ripgrep gh remmina iputils-ping net-tools socat tmux jq && rm -rf /var/lib/apt/lists/*
 
 # Copy Node.js binaries and libraries
 COPY --from=node-bin --chown=abc:abc /usr/local/bin/node /usr/local/bin/
@@ -108,5 +109,18 @@ RUN set -eux; \
     cp /tmp/mnemon /usr/local/bin/mnemon && \
     chmod +x /usr/local/bin/mnemon && \
     rm -rf /tmp/mnemon.tar.gz /tmp/mnemon
+
+# Install firstmate's pinned herdr session backend (primary fm-spawn pane backend).
+# Uses firstmate's own pinned installer (exact release asset, SHA-256, bounded download);
+# jq (herdr JSON protocol) and tmux (fallback session backend) come from the apt step above.
+# HERDR_VERSION is a bump guard: it must match the pin inside scripts/fm-install-herdr.sh
+# (build context is ./docker, so the COPY source is relative to that directory).
+ARG HERDR_VERSION
+COPY scripts/fm-install-herdr.sh /tmp/fm-install-herdr.sh
+RUN set -eux; \
+    chmod +x /tmp/fm-install-herdr.sh; \
+    /tmp/fm-install-herdr.sh /usr/local/bin; \
+    test "$(/usr/local/bin/herdr --version | awk '{print $2; exit}')" = "${HERDR_VERSION}"; \
+    rm -f /tmp/fm-install-herdr.sh
 
 EXPOSE 8888 3000

--- a/docker/scripts/fm-install-herdr.sh
+++ b/docker/scripts/fm-install-herdr.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# fm-install-herdr.sh - install CI's pinned, verified Herdr build.
+#
+# Single owner of the exact Herdr version, official release asset URL, and
+# SHA-256 pin used by the required real-Herdr CI lane. Never installs a
+# floating package-manager latest.
+#
+# Usage:
+#   fm-install-herdr.sh <destination-directory>
+#
+# Pins Herdr v0.7.4 (protocol 16), the suite-verified protocol-16 release.
+# Selects the official GitHub Releases asset for the host OS/arch, downloads
+# with a bounded max size, verifies SHA-256 before install, then refuses to
+# finish unless the binary reports the exact pin version and a client protocol
+# at or above the required floor (16 for the real-Herdr family).
+set -eu
+
+# Exact pin - change only with a re-verified real-Herdr matrix.
+FM_HERDR_CI_VERSION=0.7.4
+FM_HERDR_CI_TAG="v${FM_HERDR_CI_VERSION}"
+FM_HERDR_CI_MIN_PROTOCOL=16
+# Bounded download ceiling (bytes). The largest official 0.7.4 asset is under 20 MiB.
+FM_HERDR_CI_MAX_BYTES=25000000
+FM_HERDR_CI_REPO=ogulcancelik/herdr
+
+die() {
+  printf 'fm-install-herdr.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+DESTINATION=${1:?usage: fm-install-herdr.sh <destination-directory>}
+
+os=$(uname -s)
+arch=$(uname -m)
+case "${os}-${arch}" in
+  Linux-x86_64)
+    ASSET=herdr-linux-x86_64
+    SHA256=bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059
+    ;;
+  Linux-aarch64|Linux-arm64)
+    ASSET=herdr-linux-aarch64
+    SHA256=544e0002de42806d1ab64ccdef3a7e7414f24717b0b6b022bc9e57d2eefd26a2
+    ;;
+  Darwin-arm64)
+    ASSET=herdr-macos-aarch64
+    SHA256=24992e1625dbdcb18354a59e299e4b263c312400b31396cdc07cd46ed57f24a7
+    ;;
+  Darwin-x86_64)
+    ASSET=herdr-macos-x86_64
+    SHA256=ddf430133352e1712413d5d865b34a485546f4658893fc89986257d65a7585a8
+    ;;
+  *)
+    die "unsupported platform ${os}-${arch}; official Herdr assets are linux/macos x86_64 and aarch64"
+    ;;
+esac
+
+URL="https://github.com/${FM_HERDR_CI_REPO}/releases/download/${FM_HERDR_CI_TAG}/${ASSET}"
+TMP=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fm-herdr.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+printf 'fm-install-herdr.sh: downloading %s from %s\n' "$ASSET" "$URL" >&2
+# --fail: HTTP errors; --location: follow redirects; --max-filesize: bound.
+curl -fsSL --max-filesize "$FM_HERDR_CI_MAX_BYTES" "$URL" -o "$TMP/$ASSET" \
+  || die "download failed for $URL (bounded at $FM_HERDR_CI_MAX_BYTES bytes)"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL_SHA256=$(sha256sum "$TMP/$ASSET" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL_SHA256=$(shasum -a 256 "$TMP/$ASSET" | awk '{print $1}')
+else
+  die "need sha256sum or shasum to verify the Herdr asset"
+fi
+
+[ "$ACTUAL_SHA256" = "$SHA256" ] || die "checksum mismatch for $ASSET (expected $SHA256, got $ACTUAL_SHA256)"
+
+mkdir -p "$DESTINATION"
+install -m 0755 "$TMP/$ASSET" "$DESTINATION/herdr"
+
+# Post-install version and protocol gates (no floating latest).
+installed_version=$("$DESTINATION/herdr" --version 2>/dev/null | awk '{print $2; exit}')
+[ "$installed_version" = "$FM_HERDR_CI_VERSION" ] \
+  || die "installed herdr version is '${installed_version:-<empty>}', expected exact pin $FM_HERDR_CI_VERSION"
+
+status=$("$DESTINATION/herdr" status --json 2>/dev/null) \
+  || die "could not run 'herdr status --json' after install"
+protocol=$(printf '%s' "$status" | jq -r '.client.protocol // empty' 2>/dev/null) \
+  || die "jq is required to parse herdr status after install"
+case "$protocol" in
+  ''|*[!0-9]*) die "could not read herdr client protocol from status --json" ;;
+esac
+[ "$protocol" -ge "$FM_HERDR_CI_MIN_PROTOCOL" ] \
+  || die "herdr protocol $protocol is below the required floor $FM_HERDR_CI_MIN_PROTOCOL"
+
+printf 'fm-install-herdr.sh: installed herdr %s (protocol %s) to %s\n' \
+  "$installed_version" "$protocol" "$DESTINATION/herdr" >&2
+"$DESTINATION/herdr" --version


### PR DESCRIPTION
## What Changed
- Added a pinned, SHA-256-verified installation of the herdr session backend (v0.7.4, protocol-16 family) into the Docker image via a new build script (`docker/scripts/fm-install-herdr.sh`) that downloads the official GitHub release asset bounded by max size and verifies version/protocol gates after install.
- Added `tmux` and `jq` to the apt-installed utilities in the Dockerfile; `tmux` serves as the fallback session backend and `jq` parses herdr's JSON status protocol.
- Introduced a `HERDR_VERSION` build ARG that the Docker build enforces against the installed binary version after running the install script.

## Risk Assessment

✅ Low: Well-bounded Docker/build change that bakes a pinned, SHA-256-verified herdr binary plus tmux/jq into the image with version/protocol gates and correct multi-arch handling, presenting little ambiguity or risk.

## Testing

Exercised the new herdr install step on Linux/aarch64: the fm-install-herdr.sh script the Dockerfile runs completed end-to-end (pinned 0.7.4 asset downloaded, SHA-256 verified, installed, version 0.7.4 and protocol 16 gates passed), and `herdr --version` reports 0.7.4 matching the Dockerfile bump guard. A tampered-checksum run proved the SHA gate fails closed (exit 1). I could not build the full container image because the docker daemon is inaccessible in this sandbox, so in-image confirmation of the tmux/jq apt addition and /usr/local/bin placement is left to the remote docker-publish CI build.

<details>
<summary>Evidence: herdr installer positive run (transcript)</summary>

<code>fm-install-herdr.sh: downloading herdr-linux-aarch64 from https://github.com/ogulcancelik/herdr/releases/download/v0.7.4/herdr-linux-aarch64&#10;fm-install-herdr.sh: installed herdr 0.7.4 (protocol 16) to /tmp/herdr-test-bin/herdr&#10;herdr 0.7.4</code>

```text
fm-install-herdr.sh: downloading herdr-linux-aarch64 from https://github.com/ogulcancelik/herdr/releases/download/v0.7.4/herdr-linux-aarch64
fm-install-herdr.sh: installed herdr 0.7.4 (protocol 16) to /tmp/herdr-test-bin/herdr
herdr 0.7.4
```
</details>
<details>
<summary>Evidence: version bump-guard + SHA gate evidence</summary>

`Dockerfile ARG HERDR_VERSION=0.7.4; installed herdr --version = herdr 0.7.4 (matches); tampered-checksum installer exit = 1 (rejects mismatch)`

```text
=== Dockerfile ARG HERDR_VERSION line ===
ARG HERDR_VERSION=0.7.4
# HERDR_VERSION is a bump guard: it must match the pin inside scripts/fm-install-herdr.sh
ARG HERDR_VERSION
    test "$(/usr/local/bin/herdr --version | awk '{print $2; exit}')" = "${HERDR_VERSION}"; \
=== installed binary ===
-rwxr-xr-x 1 abc dialout 17438024 Aug 17 15:55 /tmp/herdr-test-bin/herdr
=== herdr --version (matches bump guard ARG) ===
herdr 0.7.4
=== negative SHA gate: tampered-script exit code ===
exit=1
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (1m46s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"868d9156f799525e12a070658215569c7f094cae","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Could not complete the end-to-end &#39;baked into image&#39; verification. The docker daemon is not accessible in this sandbox (docker info returns &#39;permission denied ... /var/run/docker.sock&#39;), so the full webtop image could not be built to visually confirm tmux and jq are installed by the modified apt line and that the herdr binary lands at /usr/local/bin inside the container. The substantive new behavior (fm-install-herdr.sh) was proven directly on the host, but in-container confirmation of the apt step and PATH placement relies on the remote docker-publish CI build.
- `bash docker/scripts/fm-install-herdr.sh /tmp/herdr-test-bin (positive path on Linux aarch64 — download, SHA verify, install, version+protocol gates) → exit 0, 'installed herdr 0.7.4 (protocol 16)'`
- `/tmp/herdr-test-bin/herdr --version → 'herdr 0.7.4', matching Dockerfile ARG HERDR_VERSION=0.7.4 bump guard`
- `/tmp/herdr-test-bin/herdr status --json → client protocol 16 (>= required floor 16)`
- `Negative SHA gate: copied script with aarch64 SHA256 set to 0000... → exit 1 with 'checksum mismatch'`
- `grep Dockerfile for ARG HERDR_VERSION=0.7.4 and installer pin FM_HERDR_CI_VERSION=0.7.4 to confirm bump-guard consistency`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
