### PR TITLE
fix(herdr): seed mouse_capture=false so select-to-copy works under code-server

### DIFF
--- a/docker/start-herdr.sh
+++ b/docker/start-herdr.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+source /custom-cont-init.d/common.sh || exit 1
+
+HERDR_CONFIG_DIR="/config/.config/herdr"
+HERDR_CONFIG_FILE="$HERDR_CONFIG_DIR/config.toml"
+
+runuser -l abc <<'EOF'
+source /custom-cont-init.d/common.sh || exit 1
+
+HERDR_CONFIG_DIR="/config/.config/herdr"
+HERDR_CONFIG_FILE="$HERDR_CONFIG_DIR/config.toml"
+
+# Idempotent first-boot seed: never overwrite an existing user config
+# (the /config volume is persistent across restarts / image updates).
+if [ -f "$HERDR_CONFIG_FILE" ]; then
+  echo "[start-herdr] config already present, skipping"
+  exit 0
+fi
+
+echo "[start-herdr] Seeding herdr config at $HERDR_CONFIG_FILE (first boot)"
+mkdir -p "$HERDR_CONFIG_DIR"
+
+cat > "$HERDR_CONFIG_FILE" <<'TOML'
+[ui]
+show_agent_labels_on_pane_borders = true
+# Fix: select-to-copy failing under code-server (web terminal).
+# Herdr captures pane mouse input (mouse_capture=true default) and, with the
+# default copy_on_select=true, auto-copies each drag/double-click selection to
+# the clipboard via OSC 52. In a web terminal (code-server) that OSC 52 write
+# does not reliably reach the viewing machine's real clipboard (herdr #2015
+# clipboard routing is scoped to VS Code Remote Tunnels, NOT code-server, so
+# 0.7.4 here is on the broken path). Setting mouse_capture=false hands the
+# mouse back to xterm.js, restoring native select/copy. Trade-off: herdr's
+# right-click context menu and click-to-focus pane features are disabled.
+mouse_capture = false
+TOML
+
+# Validate the TOML parses, but don't fail boot if herdr isn't on PATH yet.
+if command -v herdr >/dev/null 2>&1; then
+  if herdr config check >/dev/null 2>&1; then
+    echo "[start-herdr] herdr config check passed"
+  else
+    echo "[start-herdr] WARNING: herdr config check reported issues; leaving config in place"
+  fi
+else
+  echo "[start-herdr] herdr binary not on PATH at seed time; skipping config check"
+fi
+
+ensure_ownership "$HERDR_CONFIG_DIR"
+echo "[start-herdr] herdr config seeded successfully"
+
+EOF


### PR DESCRIPTION
## Root cause
Inside hermes-webtop, Hermes is served through code-server (a browser web terminal). In a herdr pane, drag-select-to-copy to the system clipboard silently fails.

- herdr defaults to `mouse_capture = true`, which intercepts pane mouse (SGR) events so xterm.js never gets the drag — native selection never starts.
- herdr defaults to `copy_on_select = true`, auto-copying each selection via OSC 52. Per herdr release note #2015, the OSC 52 clipboard fix is scoped to **VS Code Remote Tunnels ONLY**, not code-server. So 0.7.4 (baked into the image, PR #38) is on the broken path.

## The fix
Set `ui.mouse_capture = false` in herdr's config. This hands the mouse back to xterm.js and restores native select/copy. Setting `copy_on_select = false` alone is **insufficient** (the drag is still herdr-captured, nothing copies), so the fix is `mouse_capture = false` only.

## Implementation
Added `docker/start-herdr.sh` (auto-copied into `/custom-cont-init.d/` by the Dockerfile's `COPY *.sh`). It:
- Sources `common.sh`, runs under `runuser -l abc` (matching the other seed scripts).
- Gates on first boot only: seeds `/config/.config/herdr/config.toml` **only if it does not already exist**, so an existing user config is never overwritten on restart / image update.
- Writes the exact `[ui]` TOML block (with the explanatory comment) and runs `herdr config check` to validate; skips the check gracefully if the binary is not yet on PATH at seed time.
- Runs `ensure_ownership` on the config dir and logs a skip on second run.

## Trade-off
Disabling `mouse_capture` turns off herdr's right-click context menu and click-to-focus pane features. In the webtop (always browser-served) this is acceptable in exchange for working select-to-copy. Desktop/local herdr users are unaffected — this config is webtop-specific.

## Verification
- `bash -n docker/start-herdr.sh` passes.
- Seed test wrote a config that `herdr config check` reports as `config: ok` and that contains `mouse_capture = false`; TOML parses cleanly.
- Idempotent: second run logs `[start-herdr] config already present, skipping` and does not overwrite.
- `git diff --stat` shows only `docker/start-herdr.sh` added.