### PR TITLE
feat: default busy_input_mode to steer instead of interrupt

### DIFF
--- a/docker/start-hermes.sh
+++ b/docker/start-hermes.sh
@@ -40,6 +40,8 @@ runuser -l abc <<'EOF'
     # optimize for kanban
     hermes config set agent.max_turns 120
     hermes config set kanban.failure_limit 3
+    # default: a message typed while a turn is running steers into the run, not interrupt it
+    hermes config set display.busy_input_mode steer
 
     # Populate default skill and .hermes.md
     echo "[start-hermes] Installing Skill: memory-automation.md"


### PR DESCRIPTION
By default Hermes cancels the in-flight turn when the user types during a run (`interrupt`). Flip the webtop first-boot seeded default to `steer` so a message typed while a turn is running is injected into the current run after the next tool call instead of killing it.

This is the gentler default the captain wants for the webtop. Valid values are interrupt|queue|steer; seed value was interrupt.

Changes the first-boot seeding block in `docker/start-hermes.sh` to add:

    # default: a message typed while a turn is running steers into the run, not interrupt it
    hermes config set display.busy_input_mode steer

immediately after the `kanban.failure_limit 3` seeding line.