### PR TITLE
Update docker-publish.yml to fix mnemon ci test + pi-agent failback plugin

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -115,13 +115,14 @@ jobs:
       - name: Mnemon Integration Test
         run: |
           set -euo pipefail
+          sleep 120
           CONTAINER_NAME="hermes-webtop"
           TEST_NAME="ci-mnemon-$(date +%s)-$$"
           echo "=== Mnemon Integration Test: $TEST_NAME ==="
 
           echo "[1/3] Hermes remembers via mnemon_remember..."
           timeout 60 docker exec -u abc "$CONTAINER_NAME" \
-            hermes chat --new -q "my name is $TEST_NAME, remember this in mnemon" \
+            hermes chat -q "my name is $TEST_NAME, remember this in mnemon" \
             || { echo "FAIL: Hermes failed"; exit 1; }
 
           echo "[2/3] mnemon recall via CLI..."

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -130,13 +130,20 @@ jobs:
             mnemon recall "$TEST_NAME" --limit 5 2>&1 | grep -q "$TEST_NAME" \
             || { echo "FAIL: mnemon recall did not find $TEST_NAME"; exit 1; }
 
-          echo "[3/3] Claude retrieves via mnemon..."
+          # echo "[3/3] Claude retrieves via mnemon..."
+          # CLAUDE_OUTPUT=$(timeout 60 docker exec -u abc "$CONTAINER_NAME" \
+          #   /config/.local/bin/claude --dangerously-skip-permissions -p \
+          #   "Use mnemon recall to find my name. Reply with ONLY the name." 2>&1) || true
+          # echo "Claude: $CLAUDE_OUTPUT"
+          # echo "$CLAUDE_OUTPUT" | grep -q "$TEST_NAME" \
+          #   || { echo "FAIL: Claude did not return $TEST_NAME"; }
+          echo "[3/3] Hermes retrieves via mnemon..."
           CLAUDE_OUTPUT=$(timeout 60 docker exec -u abc "$CONTAINER_NAME" \
-            /config/.local/bin/claude --dangerously-skip-permissions -p \
+            hermes chat -q \
             "Use mnemon recall to find my name. Reply with ONLY the name." 2>&1) || true
-          echo "Claude: $CLAUDE_OUTPUT"
+          echo "Hermes: $CLAUDE_OUTPUT"
           echo "$CLAUDE_OUTPUT" | grep -q "$TEST_NAME" \
-            || { echo "FAIL: Claude did not return $TEST_NAME"; }
+            || { echo "FAIL: Hermes did not return $TEST_NAME"; }  
 
           echo "=== ALL MNEMON CHECKS PASSED ==="
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -121,7 +121,7 @@ jobs:
 
           echo "[1/3] Hermes remembers via mnemon_remember..."
           timeout 60 docker exec -u abc "$CONTAINER_NAME" \
-            hermes chat -q "my name is $TEST_NAME, remember this in mnemon" \
+            hermes chat --new -q "my name is $TEST_NAME, remember this in mnemon" \
             || { echo "FAIL: Hermes failed"; exit 1; }
 
           echo "[2/3] mnemon recall via CLI..."

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG HERMES_VERSION="v2026.8.31"
 ARG OMNIROUTE_VERSION=3.8.49
-ARG MODELRELAY_VERSION=1.18.0
+ARG MODELRELAY_VERSION=1.22.1
 ARG OLLAMA_VERSION=0.33.2
 ARG NODE_VERSION=26.7.0
 ARG CODE_SERVER_VERSION=4.135.0
@@ -63,9 +63,9 @@ RUN curl -fsSL "https://raw.githubusercontent.com/NousResearch/hermes-agent/${HE
 
 # Install ModelRelay and start automatically in the background
 ARG MODELRELAY_VERSION
-# RUN npm install -g modelrelay@${MODELRELAY_VERSION} && \
-RUN npm install -g github:gitricko/modelrelay && \
+RUN npm install -g modelrelay@${MODELRELAY_VERSION} && \
     npm cache clean --force
+# RUN npm install -g github:gitricko/modelrelay && \
 
 # Install OmniRoute and start automatically when desktop loads
 ARG OMNIROUTE_VERSION

--- a/docker/pi-models.json
+++ b/docker/pi-models.json
@@ -3,14 +3,62 @@
     "omniroute": {
       "baseUrl": "http://localhost:20128/v1",
       "api": "openai-completions",
-      "apiKey": "***",
-      "compat": {
-        "supportsDeveloperRole": false,
-        "supportsReasoningEffort": false
-      },
+      "apiKey": "no-key-needed",
       "models": [
-        { "id": "auto-fastest" }
-      ]
+        {
+          "id": "auto-fastest",
+          "name": "Auto Fastest",
+          "api": "openai-completions",
+          "provider": "omniroute",
+          "baseUrl": "http://localhost:20128/v1",
+          "reasoning": true,
+          "input": ["text"],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "contextWindow": 256000,
+          "maxTokens": 131072
+        }
+      ],
+      "fallback": {
+        "chain": ["modelrelay/auto-fastest"],
+        "timeoutMs": 30000,
+        "onlyPreFirstToken": true,
+        "notifyOnSwitch": true
+      }
+    },
+    "modelrelay": {
+      "baseUrl": "http://localhost:7352/v1",
+      "api": "openai-completions",
+      "apiKey": "no-key-needed",
+      "models": [
+        {
+          "id": "auto-fastest",
+          "name": "Auto Fastest",
+          "api": "openai-completions",
+          "provider": "modelrelay",
+          "baseUrl": "http://localhost:7352/v1",
+          "reasoning": true,
+          "input": ["text"],
+          "cost": {
+            "input": 0,
+            "output": 0,
+            "cacheRead": 0,
+            "cacheWrite": 0
+          },
+          "contextWindow": 256000,
+          "maxTokens": 131072
+        }
+      ],
+      "fallback": {
+        "chain": ["omniroute/auto-fastest"],
+        "timeoutMs": 30000,
+        "onlyPreFirstToken": true,
+        "notifyOnSwitch": true
+      }
     }
   }
 }

--- a/docker/pi-settings.json
+++ b/docker/pi-settings.json
@@ -1,4 +1,7 @@
 {
   "defaultProvider": "omniroute",
-  "defaultModel": "auto-fastest"
+  "defaultModel": "auto-fastest",
+  "packages": [
+    "git:github.com/gitricko/pi-failover@hermes-impl"
+  ]
 }

--- a/docker/start-pi.sh
+++ b/docker/start-pi.sh
@@ -27,5 +27,9 @@ if [ ! -f "$PI_DIR/settings.json" ]; then
   chown abc:abc "$PI_DIR/settings.json"
 fi
 
+# Install Pi-agent hermes like fallback extension
+echo "[$SCRIPT_NAME] Installing Pi-agent extension..."
+pi install git:github.com/gitricko/pi-failover@hermes-impl
+
 echo "[start-pi] Pi agent ready ($(pi --version 2>/dev/null || echo unknown)). Default model: omniroute/auto-fastest"
 EOF


### PR DESCRIPTION
This pull request introduces several updates to the Docker build, configuration, and integration test setup for the project. The main focus is on improving model provider failover, updating dependencies, and refining integration test logic. Below are the most important changes grouped by theme:

**Model Provider Failover & Configuration:**

* Enhanced the `docker/pi-models.json` configuration to fully define both `omniroute` and `modelrelay` providers, including detailed model specs, fallback chains, and API keys set to `"no-key-needed"` for local use. This enables robust failover between providers.
* Updated `docker/pi-settings.json` to specify a `packages` array that installs the `pi-failover` extension from a GitHub repository, supporting the new failover logic.
* Modified `docker/start-pi.sh` to automatically install the `pi-failover` extension during startup, ensuring the failover mechanism is always available.

**Dependency Updates:**

* Upgraded `modelrelay` to version `1.22.1` in the `docker/Dockerfile` and switched to direct versioned installation via npm instead of installing from a GitHub fork, ensuring compatibility and stability. [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL3-R3) [[2]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL66-R68)

**Integration Test Improvements:**

* Improved the GitHub Actions workflow (`.github/workflows/docker-publish.yml`) by adding a delay (`sleep 120`) before running the Mnemon integration test to ensure services are ready.
* Updated the integration test to use the `hermes` CLI for retrieval checks instead of `claude`, and commented out the old `claude`-based logic for clarity and future reference. Output and error messages were updated to reflect this change.This pull request updates the Mnemon integration test step in the `.github/workflows/docker-publish.yml` workflow. The main changes are to improve test reliability and switch the retrieval test from using the `claude` command to the `hermes` command.

Test reliability improvements:
* Added a `sleep 120` command before running the Mnemon integration test to allow services to fully start up, reducing the chance of race conditions.

Test logic and tool changes:
* Commented out the Claude-based retrieval test and replaced it with a Hermes-based retrieval test, updating command invocations and output checks accordingly.
* Updated log messages and variable names to reflect the switch from Claude to Hermes in the retrieval step.